### PR TITLE
PC-323: installation not allowed to write organization package

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.2.0"
+current_version = "1.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/.github/actions/smoke-test/publish.sh
+++ b/.github/actions/smoke-test/publish.sh
@@ -2,6 +2,6 @@
 TEMPLATE_ID="$1"
 
 # TODO: @alexanderilyin run .github/workflows/release.sh
-devcontainer templates apply --template-id "ghcr.io/partcad/devcontainers-templates/${TEMPLATE_ID}:1.2.0" --workspace-folder "build/${TEMPLATE_ID}" --log-level trace
+devcontainer templates apply --template-id "ghcr.io/partcad/devcontainers-templates/${TEMPLATE_ID}:1.3.0" --workspace-folder "build/${TEMPLATE_ID}" --log-level trace
 # TODO: @alexanderilyin use "--label" option to add metadata to the image
-devcontainer build --push --log-level trace --image-name "ghcr.io/partcad/devcontainer-${TEMPLATE_ID}:1.2.0" --workspace-folder "build/${TEMPLATE_ID}"
+devcontainer build --push --log-level trace --image-name "ghcr.io/partcad/devcontainer-${TEMPLATE_ID}:1.3.0" --workspace-folder "build/${TEMPLATE_ID}"

--- a/src/partcad/.devcontainer/Dockerfile
+++ b/src/partcad/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/base:bookworm
 
 
-ARG IMAGE_VERSION=1.2.0
+ARG IMAGE_VERSION=1.3.0
 
 # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
@@ -38,4 +38,17 @@ RUN \
 RUN \
   sudo apt-get update \
   && sudo apt-get install --yes moreutils \
+  && sudo rm -rf /var/lib/apt/lists/*
+
+# Install PowerShell
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# hadolint ignore=DL3004,DL4001
+RUN \
+  sudo apt-get update \
+  && sudo apt-get install -y wget apt-transport-https software-properties-common \
+  && wget -q "https://packages.microsoft.com/keys/microsoft.asc" -O- | sudo apt-key add -   \
+  && sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list' \
+  && sudo apt-get update \
+  && sudo apt-get install -y powershell \
   && sudo rm -rf /var/lib/apt/lists/*

--- a/src/partcad/devcontainer-template.json
+++ b/src/partcad/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "partcad",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "name": "PartCAD: Dev Container [base:bookworm]",
     "description": "Collaborative Assembly & Design",
     "documentationURL": "https://github.com/partcad/devcontainers-templates/tree/main/src/partcad",

--- a/src/ubik/devcontainer-template.json
+++ b/src/ubik/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ubik",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "name": "Unobtainium",
     "description": "One size, fits all.",
     "documentationURL": "https://github.com/partcad/devcontainers-templates/tree/main/src/ubik",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version from 1.2.0 to 1.3.0 across multiple configuration files
	- Updated DevContainer templates for PartCAD and Ubik
	- Updated Dockerfile with new base image version
	- Added PowerShell installation in DevContainer Dockerfile

<!-- end of auto-generated comment: release notes by coderabbit.ai -->