### PR TITLE
PC-323: Use template and build image.

### DIFF
--- a/.github/actions/smoke-test/action.yaml
+++ b/.github/actions/smoke-test/action.yaml
@@ -20,16 +20,3 @@ runs:
       id: test_template
       shell: bash
       run: ${{ github.action_path }}/test.sh  ${{ inputs.template }}
-
-#    - name: Login to GitHub Container Registry
-#      uses: docker/login-action@v3
-#      with:
-#        registry: ghcr.io
-#        username: ${{ github.actor }}
-#        password: ${{ env.GITHUB_TOKEN }}
-#
-#    # TODO: @alexanderilyin move to .github/workflows/release.yml
-#    - name: Apply Template, Build & Push Dev Container
-#      id: apply_template_build_push_dev_container
-#      shell: bash
-#      run: ${{ github.action_path }}/publish.sh  ${{ inputs.template }}

--- a/.github/actions/smoke-test/publish.sh
+++ b/.github/actions/smoke-test/publish.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-TEMPLATE_ID="$1"
 
-# TODO: @alexanderilyin run .github/workflows/release.sh
-devcontainer templates apply --template-id "ghcr.io/partcad/devcontainers-templates/${TEMPLATE_ID}:1.3.0" --workspace-folder "build/${TEMPLATE_ID}" --log-level trace
-# TODO: @alexanderilyin use "--label" option to add metadata to the image
-devcontainer build --push --log-level trace --image-name "ghcr.io/partcad/devcontainer-${TEMPLATE_ID}:1.3.0" --workspace-folder "build/${TEMPLATE_ID}"
+for TEMPLATE_ID in $(find src/ -mindepth 1 -maxdepth 1 -type d -print0 | xargs --null -n1 basename); do
+    devcontainer templates apply --template-id "ghcr.io/partcad/devcontainers-templates/${TEMPLATE_ID}:1.3.0" --workspace-folder "build/${TEMPLATE_ID}" --log-level trace
+    # TODO: @alexanderilyin use "--label" option to add metadata to the image
+    devcontainer build --push --log-level trace --image-name "ghcr.io/partcad/devcontainer-${TEMPLATE_ID}:1.3.0" --workspace-folder "build/${TEMPLATE_ID}"
+done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ env.GITHUB_TOKEN }}
+
+      - name: Apply Template, Build & Push Dev Container
+        id: apply_template_build_push_dev_container
+        shell: bash
+        run: .github/actions/smoke-test/publish.sh
+
       # - name: Create PR for Documentation
       #   id: push_image_info
       #   env:


### PR DESCRIPTION
This pull request includes several changes to streamline the smoke test and release workflows by consolidating tasks and moving steps to the appropriate workflow files.

Improvements to workflow organization:

* [`.github/actions/smoke-test/action.yaml`](diffhunk://#diff-3a4553863ce7e67616188ee10cb4e739fa67f2964d0399a1836c4e5ca89eb35fL23-L35): Removed commented-out steps related to logging into the GitHub Container Registry and building/pushing the dev container.

* [`.github/actions/smoke-test/publish.sh`](diffhunk://#diff-5a8e4a13404e4006e921055cb9444088a9114e8ddbc448e440524c017575c902L2-R7): Modified the script to loop through all template directories and apply/build/push each one, instead of using a single template ID.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR26-R37): Added steps to log into the GitHub Container Registry and to apply/build/push the dev container, which were previously commented out in the smoke test action.